### PR TITLE
Add zeroconf as default mDNS implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
  spydaap: a simple DAAP server for python
 ==========================================
 
-spydaap is a Digital Audio Access Protocol (DAAP) server -- DAAP is the 
+spydaap is a Digital Audio Access Protocol (DAAP) server -- DAAP is the
 protocol used by Apple's iTunes software.  Running spydaap on your machine
 allows any DAAP enabled music player to browse and play selections from your
 music collection (including music players running on the same machine as the
@@ -19,7 +19,9 @@ Requirements
 
 1. Python 2.5 or later
 2. `mutagen <http://code.google.com/p/mutagen/>`_
-3. `pybonjour <http://code.google.com/p/pybonjour/>`_ or python-avahi
+3. One of:
+  - python-avahi
+  - `zeroconf <https://github.com/jstasiak/python-zeroconf>`_
 
 
 Running without installing

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,15 @@ reqs = ["mutagen>=1.2"]
 try:
     import avahi
 except ImportError:
-    reqs.append("pybonjour>=1.1")
+    import sys
+    if sys.version_info[0] < 3:
+        reqs.append("zeroconf<0.20")
+    else:
+        reqs.append("zeroconf")
 
 setup(
     name="spydaap",
-    version="0.1",
+    version="0.2",
     author="Erik Hetzner",
     author_email="egh@e6h.org",
     description="A simple DAAP server",
@@ -21,7 +25,7 @@ setup(
 
 Spydaap is a media server supporting the DAAP protocol (aka iTunes
 sharing). It is written in Python, uses the mutagen media metadata
-library, and either the Avahi or pybonjour Zeroconf implementation.
+library, and either the Avahi or python-zeroconf implementation.
 
 Features:
 
@@ -33,7 +37,7 @@ Features:
  - Embeddable.
 
 Note: This pypi package is maintained by the Exaile project, but will be kept in
-sync with the upstream spydaap project. 
+sync with the upstream spydaap project.
  
 """,
     url="https://github.com/egh/spydaap",

--- a/spydaap/cli.py
+++ b/spydaap/cli.py
@@ -32,7 +32,7 @@ import spydaap.metadata
 import spydaap.containers
 import spydaap.cache
 import spydaap.server
-import spydaap.zeroconf
+import spydaap.zeroconfimpl
 
 config_file = os.path.join(spydaap.spydaap_dir, "config.py")
 if os.path.isfile(config_file):
@@ -96,9 +96,9 @@ def make_shutdown(httpd):
 
 def really_main(opts, parent_pid=99999999999999):
     rebuild_cache()
-    zeroconf = spydaap.zeroconf.Zeroconf(spydaap.server_name,
-                                         spydaap.port,
-                                         stype="_daap._tcp")
+    zeroconf = spydaap.zeroconfimpl.ZeroconfImpl(spydaap.server_name,
+                                                 spydaap.port,
+                                                 stype="_daap._tcp")
     zeroconf.publish()
     try:
         httpd = MyThreadedHTTPServer(('0.0.0.0', spydaap.port),


### PR DESCRIPTION
- Fixes #10

.. I'm able to see the information published via `dns-sd`, and I can ping the published service name. However, I don't really know how to test the actual DAAP thing, so who knows if it works. But, better than the current situation I suppose?