### PR TITLE
zeroconfimpl: set helper member to None if no zeroconf is available

### DIFF
--- a/spydaap/zeroconfimpl.py
+++ b/spydaap/zeroconfimpl.py
@@ -110,6 +110,7 @@ class ZeroconfImpl(object):
         
         else:
             logger.warning('zeroconf implementation not found, cannot announce presence')
+            self.helper = None
 
 
     def publish(self, *args, **kwargs):


### PR DESCRIPTION
Otherwise, publish() and unpublish() will complain about missing
member when no zeroconf implementation is available.